### PR TITLE
Removing magic $value assignment

### DIFF
--- a/XEditable.php
+++ b/XEditable.php
@@ -553,24 +553,6 @@ class XEditable extends \yii\base\Widget
 		}
 	}
 
-	public static function saveAction($data)
-	{
-		$model = ArrayHelper::getValue($data,'model');
-		$name = ArrayHelper::getValue($data,'name');
-		$value = ArrayHelper::getValue($data,'value');
-
-		if($model===null)
-			throw new NotFoundHttpException();
-		
-		$model->$name = $value;
-
-		if ($model->validate()){
-			$model->update();
-		}else{
-			VarDumper::dump($model->getErrors(),10);
-		}
-	}
-
 	/**
 	 * @see Xeditable
 	 * @see Register assets from this extension and yours types

--- a/XEditable.php
+++ b/XEditable.php
@@ -561,16 +561,8 @@ class XEditable extends \yii\base\Widget
 
 		if($model===null)
 			throw new NotFoundHttpException();
-		if(!is_array($value)){
-			if (strtotime($value))
-			{
-				$model->$name = strtotime($value);
-			}else{
-				$model->$name = $value;
-			}
-		}else{
-			$model->$name = implode(',', $value);
-		}
+		
+		$model->$name = $value;
 
 		if ($model->validate()){
 			$model->update();


### PR DESCRIPTION
When I try to save a float value it is converted to a timestamp unexpectedly. I think that there's no need for this kind of actions and the processing should be performed by the model.
