### PR TITLE
Added attribute identificator to jquery selector

### DIFF
--- a/XEditableColumn.php
+++ b/XEditableColumn.php
@@ -80,7 +80,7 @@ class XEditableColumn extends DataColumn
 		$this->view = \Yii::$app->getView();
 		XEditableAsset::register($this->view);
 		$this->editable = Json::encode($this->editable);
-		$this->view->registerJs('$(".editable").editable(' . $this->editable . ');');
+		$this->view->registerJs('$(".editable[data-name=' . $this->attribute . ']").editable(' . $this->editable . ');');
 	}
 
 } 


### PR DESCRIPTION
It was getting error on having more than two XEditableColumns with different attribute type in gridview.
The source list wasnt loaded:

``` javascript
$(".editable").editable({"placement":"top"});
$(".editable").editable({"source":[{"value":1,"text":"yes"},{"value":0,"text":"no"}],"placement":"top"});
```
